### PR TITLE
solving issue #5: style not correctly loading

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,7 +25,7 @@ function draw (style){
  * callback should indicate style info
  */
 function draw1style (style, callback){
-	jQuery.ajax('./lib/plugins/flowchartjs/styles/' + style + '.json', {dataType: 'json'})
+	jQuery.ajax('/lib/plugins/flowchartjs/styles/' + style + '.json', {dataType: 'json'})
 		.done(function(d){
 			callback(d);
 		})


### PR DESCRIPTION
solving issue #5 

if dokuwiki is configured for www.yyy.xxx/parent/structure/page url style the script tries to load www.yyy.xxx/parent/structure/page/lib/plugins/flowchartjs/styles/style.json - changed to absolute path for correct behavior